### PR TITLE
tb report and tb session save

### DIFF
--- a/packages/cli/src/commands/report-open.ts
+++ b/packages/cli/src/commands/report-open.ts
@@ -1,0 +1,73 @@
+import { Command } from 'commander';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { spawn } from 'child_process';
+
+const SUITES_DIR = 'suites';
+const CONFIG_FILE = 'test-boss.config.json';
+
+interface TestBossConfig {
+  defaultSuite: string | null;
+  defaultEnv: string;
+  ai: {
+    enabled: boolean;
+    provider: string;
+    model: string;
+    maxTokens: number;
+  };
+}
+
+export const reportOpenCommand = new Command()
+  .name('open')
+  .description('Open the last Playwright HTML report for the specified suite.')
+  .option('--suite <name>', 'Name of the test suite')
+  .action(async (options: { suite?: string }) => {
+    const projectRoot = process.cwd();
+
+    // 1. Load Test Boss Config
+    const configPath = path.join(projectRoot, CONFIG_FILE);
+    if (!fs.existsSync(configPath)) {
+      console.error('Error: Test Boss not initialized. Run `tb init` first.');
+      process.exit(1);
+    }
+    const config: TestBossConfig = JSON.parse(await fs.readFile(configPath, 'utf8'));
+
+    const suiteName = options.suite || config.defaultSuite;
+    if (!suiteName) {
+      console.error('Error: No suite specified. Use --suite option or set defaultSuite in test-boss.config.json.');
+      process.exit(1);
+    }
+
+    const suitePath = path.join(projectRoot, SUITES_DIR, suiteName);
+    if (!fs.existsSync(suitePath)) {
+      console.error(`Error: Suite '${suiteName}' not found at ${suitePath}.`);
+      process.exit(1);
+    }
+
+    // 2. Locate the latest Playwright HTML report
+    const reportPath = path.join(suitePath, 'artifacts', 'last-run', 'playwright-report', 'index.html');
+
+    if (!fs.existsSync(reportPath)) {
+      console.error(`Error: Playwright HTML report not found for suite '${suiteName}' at ${reportPath}. Run 	lb run	 first.`);
+      process.exit(1);
+    }
+
+    console.log(`Opening Playwright HTML report for suite '${suiteName}': ${reportPath}`);
+
+    // 3. Open the report in the default web browser
+    // Using 'open' command for macOS, which is generally available.
+    const openProcess = spawn('open', [reportPath], { stdio: 'inherit' });
+
+    openProcess.on('error', (err) => {
+      console.error('Failed to open report:', err);
+      process.exit(1);
+    });
+
+    openProcess.on('close', (code) => {
+      if (code !== 0) {
+        console.error(`Command 'open' exited with code ${code}.`);
+        console.error('Ensure you have a default browser configured or try opening the file manually.');
+        process.exit(1);
+      }
+    });
+  });

--- a/packages/cli/src/commands/session-save.ts
+++ b/packages/cli/src/commands/session-save.ts
@@ -1,0 +1,111 @@
+import { Command } from 'commander';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { chromium } from 'playwright';
+import * as yaml from 'js-yaml';
+
+const SUITES_DIR = 'suites';
+const CONFIG_FILE = 'test-boss.config.json';
+
+interface TestBossConfig {
+  defaultSuite: string | null;
+  defaultEnv: string;
+  ai: {
+    enabled: boolean;
+    provider: string;
+    model: string;
+    maxTokens: number;
+  };
+}
+
+interface EnvConfig {
+  name: string;
+  loginHost: string;
+  baseUrl: string;
+  playwright: {
+    headless: boolean;
+    viewport: { width: number; height: number };
+  };
+  timeouts: {
+    actionMs: number;
+    expectMs: number;
+  };
+  ai: {
+    enabled: boolean;
+    provider: string;
+    model: string;
+    maxTokens: number;
+  };
+}
+
+export const sessionSaveCommand = new Command()
+  .name('save')
+  .description('Save the current browser storage state for a named session.')
+  .option('--suite <name>', 'Name of the test suite')
+  .option('--env <name>', 'Environment to use (e.g., sit)', 'sit')
+  .option('--session <name>', 'Named session to save', 'default')
+  .action(async (options: { suite?: string; env: string; session: string }) => {
+    const projectRoot = process.cwd();
+
+    // 1. Load Test Boss Config
+    const configPath = path.join(projectRoot, CONFIG_FILE);
+    if (!fs.existsSync(configPath)) {
+      console.error('Error: Test Boss not initialized. Run `tb init` first.');
+      process.exit(1);
+    }
+    const config: TestBossConfig = JSON.parse(await fs.readFile(configPath, 'utf8'));
+
+    const suiteName = options.suite || config.defaultSuite;
+    if (!suiteName) {
+      console.error('Error: No suite specified. Use --suite option or set defaultSuite in test-boss.config.json.');
+      process.exit(1);
+    }
+
+    const suitePath = path.join(projectRoot, SUITES_DIR, suiteName);
+    if (!fs.existsSync(suitePath)) {
+      console.error(`Error: Suite '${suiteName}' not found at ${suitePath}.`);
+      process.exit(1);
+    }
+
+    // 2. Load Environment Config
+    const envConfigPath = path.join(suitePath, 'env', `${options.env}.yaml`);
+    if (!fs.existsSync(envConfigPath)) {
+      console.error(`Error: Environment config '${options.env}.yaml' not found for suite '${suiteName}'.`);
+      process.exit(1);
+    }
+    const envConfig: EnvConfig = yaml.load(await fs.readFile(envConfigPath, 'utf8')) as EnvConfig;
+
+    const loginHost = envConfig.loginHost;
+    if (!loginHost) {
+      console.error('Error: loginHost not configured in environment YAML. Cannot save session without a login host.');
+      process.exit(1);
+    }
+
+    const storageStatePath = path.join(suitePath, '.auth', `storage-state.${options.session}.json`);
+    await fs.ensureDir(path.dirname(storageStatePath));
+
+    console.log(`Launching browser to save session '${options.session}' for suite '${suiteName}'...`);
+    console.log(`Please log in manually at: ${loginHost}`);
+
+    const browser = await chromium.launch({ headless: false });
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto(loginHost);
+
+    // Keep the browser open until the user closes it or a specific event occurs.
+    // For now, we'll wait for the user to manually close the browser.
+    // In a real scenario, you might want to listen for a specific navigation or a timeout.
+    console.log('Browser launched. Please log in manually. Close the browser when done.');
+
+    // A simple way to wait for the user to close the browser is to poll for its existence.
+    // This is a basic implementation and can be improved with more robust event listeners.
+    while (browser.isConnected()) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+
+    await context.storageState({ path: storageStatePath });
+    console.log(`Session '${options.session}' storage state saved to: ${storageStatePath}`);
+
+    await browser.close();
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,8 @@ import { initCommand } from './commands/init';
 import { suiteCreateCommand } from './commands/suite-create';
 import { stepRecordCommand } from './commands/step-record';
 import { runCommand } from './commands/run';
+import { reportOpenCommand } from './commands/report-open';
+import { sessionSaveCommand } from './commands/session-save';
 
 const program = new Command();
 
@@ -18,6 +20,8 @@ const suiteCommand = new Command('suite')
 suiteCommand.addCommand(suiteCreateCommand);
 suiteCommand.addCommand(stepRecordCommand);
 suiteCommand.addCommand(runCommand);
+suiteCommand.addCommand(reportOpenCommand);
+suiteCommand.addCommand(sessionSaveCommand);
 program.addCommand(suiteCommand);
 
 // Add other commands here as they are implemented


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add 'suite open' to launch HTML report

- Add 'suite save' to persist auth session

- Wire new commands into CLI program

- Validate configs, suite, and env paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI program"] --> SuiteCmd["suite command"]
  SuiteCmd --> OpenCmd["open report command"]
  SuiteCmd --> SaveCmd["save session command"]
  OpenCmd -- reads --> Config["test-boss.config.json"]
  OpenCmd -- opens --> PWReport["playwright-report/index.html"]
  SaveCmd -- reads --> EnvYAML["env/<env>.yaml"]
  SaveCmd -- saves --> StorageState[".auth/storage-state.<session>.json"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>report-open.ts</strong><dd><code>New command to open latest Playwright HTML report</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/src/commands/report-open.ts

<ul><li>Introduce 'suite open' command to open last Playwright HTML report.<br> <li> Read suite from CLI or config; validate paths and report existence.<br> <li> Spawn OS 'open' command; add error/exit handling.</ul>


</details>


  </td>
  <td><a href="https://github.com/manu72/testboss/pull/11/files#diff-2044874752b4bdb6e8057f28bcdbaed8b51a28b55aa13f82e2045e4199f5b613">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>session-save.ts</strong><dd><code>Command to save named Playwright session state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/src/commands/session-save.ts

<ul><li>Add 'suite save' command to store browser storage state.<br> <li> Load env YAML and config; validate suite/env.<br> <li> Launch Chromium, navigate to loginHost, await manual login.<br> <li> Persist storage state to '.auth/storage-state.<session>.json'.</ul>


</details>


  </td>
  <td><a href="https://github.com/manu72/testboss/pull/11/files#diff-6a088f76d05bc9ac5e1591fd174d468b9f04b7e509c7b3eb795171b14afbcc49">+111/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Wire new commands into CLI entrypoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/src/index.ts

<ul><li>Register new 'report-open' and 'session-save' under suite command.<br> <li> Import new command modules.</ul>


</details>


  </td>
  <td><a href="https://github.com/manu72/testboss/pull/11/files#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

